### PR TITLE
Add "percentage" option to scale images

### DIFF
--- a/lib/gm.js
+++ b/lib/gm.js
@@ -17,6 +17,7 @@ module.exports = function (file, options, callback) {
     overwrite: true,
     quality: 100,
     rename: null,
+    resizeQualifier: '^',
     sharpen: false,
     upscale: false
   });
@@ -32,11 +33,17 @@ module.exports = function (file, options, callback) {
       }
 
       if (options.height !== null || options.width !== null) {
+        var isPercentage = options.resizeQualifier === '%';
         var isUpscaled = (options.width && size.width < options.width) ||
           (options.height && size.height < options.height);
 
-        if (options.upscale || !isUpscaled) {
-          if (isUpscaled) {
+        if (options.upscale || !isUpscaled || isPercentage) {
+          //Allow to specify only one "percentage" and default the other to
+          //to the same value
+          if (isPercentage) {
+            options.height = options.height || options.width;
+            options.width = options.width || options.height;
+          } else if (isUpscaled) {
             if (!options.height) {
               options.height = Math.ceil((options.width / size.width) * size.height);
             }
@@ -46,7 +53,7 @@ module.exports = function (file, options, callback) {
           }
 
           if (options.crop) {
-            gmFile = gmFile.resize(options.width, options.height, '^');
+            gmFile = gmFile.resize(options.width, options.height, resizeQualifier);
             gmFile = gmFile.gravity(options.gravity);
             gmFile = gmFile.crop(options.width, options.height);
           } else {

--- a/lib/gm.js
+++ b/lib/gm.js
@@ -17,7 +17,7 @@ module.exports = function (file, options, callback) {
     overwrite: true,
     quality: 100,
     rename: null,
-    resizeQualifier: '^',
+    percentage: false,
     sharpen: false,
     upscale: false
   });
@@ -33,7 +33,8 @@ module.exports = function (file, options, callback) {
       }
 
       if (options.height !== null || options.width !== null) {
-        var isPercentage = options.resizeQualifier === '%';
+        var isPercentage = options.percentage;
+        var qualifier = isPercentage ? '%' : null;
         var isUpscaled = (options.width && size.width < options.width) ||
           (options.height && size.height < options.height);
 
@@ -53,11 +54,11 @@ module.exports = function (file, options, callback) {
           }
 
           if (options.crop) {
-            gmFile = gmFile.resize(options.width, options.height, resizeQualifier);
+            gmFile = gmFile.resize(options.width, options.height, '^');
             gmFile = gmFile.gravity(options.gravity);
             gmFile = gmFile.crop(options.width, options.height);
           } else {
-            gmFile = gmFile.resize(options.width, options.height);
+            gmFile = gmFile.resize(options.width, options.height, qualifier);
           }
         }
       }


### PR DESCRIPTION
This should be useful to generate non-retina images and the likes

``` javascript
'*_2x.png' : [{
          width: 50,
          height: 50,
          percentage: true,
          rename: function(obj) {
            return {
              basename: obj.basename.replace('_2x', '_1x')
            };
          }
```
