### PR TITLE
update minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gm": "^1.18.1",
     "gulp-util": "^3.0.6",
     "lodash": "^3.10.1",
-    "minimatch": "^2.0.10",
+    "minimatch": "^3.0.4",
     "rename": "^1.0.3",
     "through2": "^2.0.0"
   }


### PR DESCRIPTION
Hi, dcgauld. I was getting a severe vulnerability warning from an outdated version of minimatch in your otherwise wonderful gulp plugin. I took the time to update the dependency, and tested the plugin in my own build system. It works flawlessly. 